### PR TITLE
Make template annotation obey k8s regex

### DIFF
--- a/tyk/tyk.go
+++ b/tyk/tyk.go
@@ -5,6 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path"
+	"regexp"
+	"strings"
+	"text/template"
+
 	"github.com/TykTechnologies/tyk-git/clients/dashboard"
 	"github.com/TykTechnologies/tyk-git/clients/gateway"
 	"github.com/TykTechnologies/tyk-git/clients/interfaces"
@@ -13,10 +18,6 @@ import (
 	"github.com/TykTechnologies/tyk-k8s/processor"
 	"github.com/satori/go.uuid"
 	"github.com/spf13/viper"
-	"path"
-	"regexp"
-	"strings"
-	"text/template"
 )
 
 func cleanSlug(s string) string {
@@ -64,7 +65,7 @@ var defaultTemplate *template.Template
 
 const (
 	DefaultTemplate = "default"
-	TemplateNameKey = "template.service.tyk.io/"
+	TemplateNameKey = "template.service.tyk.io"
 )
 
 func Init(forceConf *TykConf) {


### PR DESCRIPTION
As the template annotation doesn't accept a `name` part after the slash it is required by the regex in kubectl to have no slash at all - this mean up til this point templates would not be applied properly.