### PR TITLE
Template must end .json

### DIFF
--- a/tyk/tyk.go
+++ b/tyk/tyk.go
@@ -85,7 +85,7 @@ func Init(forceConf *TykConf) {
 
 	if cfg.Templates != "" {
 		log.Info("template directory detected, loading from ", cfg.Templates)
-		templates = template.Must(template.ParseGlob(path.Join(cfg.Templates, "*")))
+		templates = template.Must(template.ParseGlob(path.Join(cfg.Templates, "*.json")))
 	}
 
 	if cfg.InsecureSkipVerify {


### PR DESCRIPTION
Lets us avoid trying to parse the hidden directories that appear when configmaps in k8s mount a file in a volume