### PR TITLE
Update Tyk for Kubernetes helm chart url and text

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Removing an ingress will then remove the corresponding API definition.
 
 ### Installation
 
-It is recommended to use the [tyk-k8s Helm chart which is available here](https://github.com/TykTechnologies/tyk-k8s-helm).
+It is recommended to use the [Tyk for Kubernetes Helm chart which is available here](https://github.com/TykTechnologies/tyk-helm-chart).
 
 ### Usage:
 


### PR DESCRIPTION
The helm chart url points to a repository that no longer exists. The link's text was also updated to better match the new repository's name.