### PR TITLE
create new dockerfile, 53mb large, tested with helm chart

### DIFF
--- a/docker/controller/Dockerfile
+++ b/docker/controller/Dockerfile
@@ -1,8 +1,35 @@
-FROM centos
+# Start from the latest golang base image
+FROM golang:latest as builder
+
+# Set the Current Working Directory inside the container
+WORKDIR /app
+
+# Copy go mod and sum files
+COPY go.mod go.sum ./
+
+# Download all dependencies. Dependencies will be cached if the go.mod and go.sum files are not changed
+RUN go mod download
+
+# Copy the source from the current directory to the Working Directory inside the container
+COPY . .
+
+# Build the Go app
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o tyk-k8s .
+
+
+######## Start a new stage from scratch #######
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
 
 RUN mkdir -p /opt/tyk-k8s
-COPY files/build/tyk-k8s /opt/tyk-k8s/tyk-k8s
-
 WORKDIR /opt/tyk-k8s
 
-CMD ["/opt/goproxy/tyk-k8s", "start"]
+# Copy the Pre-built binary file from the previous stage
+COPY --from=builder /app/tyk-k8s /opt/tyk-k8s/tyk-k8s
+
+# Expose port 8080 to the outside world
+EXPOSE 8080
+
+# Command to run the executable
+CMD ["./tyk-k8s", "start"]

--- a/docker/controller/Dockerfile
+++ b/docker/controller/Dockerfile
@@ -1,5 +1,5 @@
 # Start from the latest golang base image
-FROM golang:latest as builder
+FROM golang:1.13 as builder
 
 # Set the Current Working Directory inside the container
 WORKDIR /app
@@ -18,9 +18,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o tyk-k8s .
 
 
 ######## Start a new stage from scratch #######
-FROM alpine:latest
-
-RUN apk --no-cache add ca-certificates
+FROM debian:buster-slim
 
 RUN mkdir -p /opt/tyk-k8s
 WORKDIR /opt/tyk-k8s
@@ -28,5 +26,6 @@ WORKDIR /opt/tyk-k8s
 # Copy the Pre-built binary file from the previous stage
 COPY --from=builder /app/tyk-k8s /opt/tyk-k8s/tyk-k8s
 
-# Command to run the executable
-CMD ["./tyk-k8s", "start"]
+ENTRYPOINT ["./tyk-k8s"]
+
+CMD ["start"]

--- a/docker/controller/Dockerfile
+++ b/docker/controller/Dockerfile
@@ -14,7 +14,7 @@ RUN go mod download
 COPY . .
 
 # Build the Go app
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o tyk-k8s .
+RUN CGO_ENABLED=0 go build -o tyk-k8s .
 
 
 ######## Start a new stage from scratch #######

--- a/docker/controller/Dockerfile
+++ b/docker/controller/Dockerfile
@@ -28,8 +28,5 @@ WORKDIR /opt/tyk-k8s
 # Copy the Pre-built binary file from the previous stage
 COPY --from=builder /app/tyk-k8s /opt/tyk-k8s/tyk-k8s
 
-# Expose port 8080 to the outside world
-EXPOSE 8080
-
 # Command to run the executable
 CMD ["./tyk-k8s", "start"]


### PR DESCRIPTION
Old Dockerfile was not working.  this one is tested as drop-in replacement for helm chart and down to 53.1MB from 266MB
